### PR TITLE
Fix Span::merge and add test

### DIFF
--- a/parser/src/span.rs
+++ b/parser/src/span.rs
@@ -32,7 +32,7 @@ impl Span {
 
     pub fn merge(self, other: &Span) -> Self {
         Self {
-            start: cmp::max(self.start, other.start),
+            start: cmp::min(self.start, other.start),
             end: cmp::max(self.end, other.end),
         }
     }

--- a/parser/src/tests.rs
+++ b/parser/src/tests.rs
@@ -201,3 +201,18 @@ mod tokenizer {
         }
     }
 }
+
+mod span {
+    use crate::span::Span;
+
+    #[test]
+    fn merge() {
+        let a = Span::range(1, 5);
+        let b = Span::range(3, 10);
+
+        let merged = a.merge(&b);
+
+        assert_eq!(merged.start, 1);
+        assert_eq!(merged.end, 10);
+    }
+}


### PR DESCRIPTION
## Summary
- correct `Span::merge` to use the earliest start position
- add tests for `Span::merge`

## Testing
- `cargo test` *(fails: failed to fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_6862bf952d7c8332b5826f419d23e54a